### PR TITLE
Separate image and pixel transformations

### DIFF
--- a/rubiks/__init__.py
+++ b/rubiks/__init__.py
@@ -3,4 +3,5 @@ from .constants import *
 from .methods import *
 from .colour_class import Colour
 from .palette_class import Palette, PaletteWeights
+from .pixel_transformations import recolour_closest_weighted
 from .transformations import Transformation, NoneTransformation, RecolourClosest

--- a/rubiks/colour_class.py
+++ b/rubiks/colour_class.py
@@ -43,21 +43,21 @@ class Colour(list):
         self.__update(channel_format)
 
     @property
-    def values(self):
+    def values(self) -> list[int]:
         """
         The list of colour channel values.
         """
         return self._values
 
     @property
-    def format(self):
+    def format(self) -> list[str]:
         """
         The list of colour channel names.
         """
         return self._format
 
     @property
-    def channel_dict(self):
+    def channel_dict(self) -> dict[str, int]:
         """
         A dictionary mapping the channel names to their corresponding values.
         """

--- a/rubiks/palette_class.py
+++ b/rubiks/palette_class.py
@@ -239,6 +239,26 @@ class PaletteWeights(dict):
         """
         return self._weights_dict
 
+    def validate_against_palette(self, palette: Palette) -> None:
+        """
+        Do input validation for the palette weights against a palette. Checks that they are 1:1 in terms of colours.
+
+        :param palette: a Palette of Colours.
+
+        :return: None
+        """
+        # Check that each colour in the palette has a weight:
+        colours_with_no_weight = [colour_name for colour_name in palette.names if colour_name not in self._names]
+        if colours_with_no_weight:
+            raise ValueError(f"The following colours were not assigned weights:\n{colours_with_no_weight}")
+
+        # Check that only colours from the palette are in the weights:
+        extra_colours = [colour_name for colour_name in self._names if colour_name not in palette.names]
+        if extra_colours:
+            raise ValueError(
+                f"The following colours are not in the palette but were assigned weights:\n{extra_colours}"
+            )
+
     def __update(self) -> None:
         """
         Updates various attributes.

--- a/rubiks/palette_class.py
+++ b/rubiks/palette_class.py
@@ -219,21 +219,21 @@ class PaletteWeights(dict):
         self.__update()
 
     @property
-    def names(self):
+    def names(self) -> list[str]:
         """
         The list of colour names. Equivalent of dictionary keys.
         """
         return self._names
 
     @property
-    def weights(self):
+    def weights(self) -> list[float | int]:
         """
         The list of weights. Equivalent of dictionary values.
         """
         return self._weights
 
     @property
-    def weights_dict(self):
+    def weights_dict(self) -> dict[str, float | int]:
         """
         The dictionary mapping colour names to weights. Equivalent of dictionary.
         """

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -1,0 +1,37 @@
+"""
+Rubiks pixel transformations.
+"""
+
+import numpy as np
+from .palette_class import Palette, PaletteWeights
+
+
+def recolour_closest_weighted(pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
+    """
+    Change the colour of the pixel to the one from the palette which is geometrically closest.
+
+    :param pixel: a pixel.
+    :param palette: a palette of colours from which the final image will be constructed. All colours must have the
+    same channel format as a cv2.Mat.
+    :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
+    influence each colour has.
+
+    :return: the transformed pixel.
+    """
+    # Measure the Euclidean distance to the pixel colour of each colour in the palette:
+    distances = {
+        colour_name: np.linalg.norm(pixel - np.array(colour)) / palette_weights[colour_name]
+        for colour_name, colour in palette.colour_dict.items()
+    }
+
+    # Find the minimum distance:
+    smallest_distance = min(distances.values())
+    # Create a list of all the colour names with this distance:
+    colours_with_smallest_distance = [
+        colour_name for colour_name, distance in distances.items() if distance == smallest_distance
+    ]
+
+    # Choose one of these colours randomly:
+    closest_colour = np.random.choice(colours_with_smallest_distance)
+
+    return palette[closest_colour]

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -34,4 +34,4 @@ def recolour_closest_weighted(pixel: np.ndarray, palette: Palette, palette_weigh
     # Choose one of these colours randomly:
     closest_colour = np.random.choice(colours_with_smallest_distance)
 
-    return palette[closest_colour]
+    return np.array(palette[closest_colour])

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -7,6 +7,7 @@ import numpy as np
 import cv2
 from .palette_class import Palette, PaletteWeights
 from .constants import CV2_CHANNEL_FORMAT
+from .pixel_transformations import recolour_closest_weighted
 
 
 class Transformation(ABC):
@@ -116,23 +117,8 @@ class RecolourClosest(Transformation):
 
         :return: the transformed pixel.
         """
-        # Measure the Euclidean distance to the pixel colour of each colour in the palette:
-        distances = {
-            colour_name: np.linalg.norm(pixel - np.array(colour)) / palette_weights[colour_name]
-            for colour_name, colour in palette.colour_dict.items()
-        }
 
-        # Find the minimum distance:
-        smallest_distance = min(distances.values())
-        # Create a list of all the colour names with this distance:
-        colours_with_smallest_distance = [
-            colour_name for colour_name, distance in distances.items() if distance == smallest_distance
-        ]
-
-        # Choose one of these colours randomly:
-        closest_colour = np.random.choice(colours_with_smallest_distance)
-
-        return palette[closest_colour]
+        return recolour_closest_weighted(pixel, palette, palette_weights)
 
     @staticmethod
     def _validate_palette(palette: Palette) -> Palette:

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -148,18 +148,7 @@ class RecolourClosest(Transformation):
         if palette_weights is None:
             palette_weights = PaletteWeights({colour_name: 1 for colour_name in palette.names})
 
-        # Check that each colour in the palette has a weight:
-        colours_with_no_weight = [
-            colour_name for colour_name in palette.names if colour_name not in palette_weights.names
-        ]
-        if colours_with_no_weight:
-            raise ValueError(f"The following colours were not assigned weights:\n{colours_with_no_weight}")
-
-        # Check that only colours from the palette are in the weights:
-        extra_colours = [colour_name for colour_name in palette_weights.names if colour_name not in palette.names]
-        if extra_colours:
-            raise ValueError(
-                f"The following colours are not in the palette but were assigned weights:\n{extra_colours}"
-            )
+        # Check that the palette weights and palette share the same colours:
+        palette_weights.validate_against_palette(palette)
 
         return palette_weights

--- a/test/test_palette.py
+++ b/test/test_palette.py
@@ -2,6 +2,7 @@ import unittest
 
 from rubiks.colour_class import Colour
 from rubiks.palette_class import Palette, PaletteWeights, DEFAULT_COLOUR_DICT
+from rubiks.constants import RUBIKS_PALETTE
 
 
 class PaletteTest(unittest.TestCase):
@@ -157,7 +158,7 @@ class PaletteWeightsTest(unittest.TestCase):
 
     def test_setitem(self) -> None:
         """
-        Test that dict[key] = value (__setitem__) works on Palette.
+        Test that dict[key] = value (__setitem__) works on PaletteWeights.
         """
         self.rubiks_palette_weights["green"] = 15
         equivalent_palette_weights = PaletteWeights(
@@ -171,3 +172,53 @@ class PaletteWeightsTest(unittest.TestCase):
             }
         )
         self.assertEqual(self.rubiks_palette_weights, equivalent_palette_weights)
+
+    def test_validate_against_palette(self) -> None:
+        """
+        Test that the validate_against_palette method does not raise an error when validating against a valid Palette.
+        """
+        weights = PaletteWeights(
+            {
+                "green": 15,
+                "white": 2,
+                "red": 3,
+                "yellow": 4.5,
+                "blue": 5,
+                "orange": 6,
+            }
+        )
+        weights.validate_against_palette(RUBIKS_PALETTE)
+
+    def test_validate_against_palette_colour_with_no_weight(self) -> None:
+        """
+        Test that the validate_against_palette method raises a ValueError when validating against an invalid Palette.
+        """
+        weights = PaletteWeights(
+            {
+                "green": 15,
+                "white": 2,
+                "red": 3,
+                "yellow": 4.5,
+                "blue": 5,
+            }
+        )
+        with self.assertRaises(ValueError):
+            weights.validate_against_palette(RUBIKS_PALETTE)
+
+    def test_validate_against_palette_extra_colour(self) -> None:
+        """
+        Test that the validate_against_palette method raises a ValueError when validating against an invalid Palette.
+        """
+        weights = PaletteWeights(
+            {
+                "green": 15,
+                "white": 2,
+                "red": 3,
+                "yellow": 4.5,
+                "blue": 5,
+                "orange": 6,
+                "orange2": 6,
+            }
+        )
+        with self.assertRaises(ValueError):
+            weights.validate_against_palette(RUBIKS_PALETTE)

--- a/test/test_pixel_tranformations.py
+++ b/test/test_pixel_tranformations.py
@@ -1,0 +1,25 @@
+import numpy as np
+import unittest
+
+from rubiks.constants import RUBIKS_PALETTE
+from rubiks.pixel_transformations import recolour_closest_weighted
+
+
+class RecolourClosestWeightedTest(unittest.TestCase):
+    """
+    Test the recolour_closest_weighted function.
+    """
+
+    def setUp(self) -> None:
+
+        self.pixel = np.array([200, 200, 200], dtype=np.uint8)
+        self.palette = RUBIKS_PALETTE
+        self.weights = {colour_name: 1 for colour_name in self.palette.names}
+
+    def test_regular(self) -> None:
+        """
+        Test that recolouring a pixel returns the expected colour.
+        """
+        np.testing.assert_array_equal(
+            recolour_closest_weighted(self.pixel, self.palette, self.weights), np.array([255, 255, 255])
+        )


### PR DESCRIPTION
Closes #16 

Move pixel transformation methods to their own module.

# Description
Simplify the image transformation code by:
- moving pixel transformation methods to their own module
- moving the method that validates a `PaletteWeights` instance against a `Palette` to the `PaletteWeights` class.

# Tests
* [x] CI pipeline passes

## Evidence
~~Add evidence of the above tests having been completed here, via screenshots, links, or text.~~

# Documentation
* [ ] ~~Documentation updated (where relevant - please provide a link!)~~

# Test coverage
* [x] New code covered by unit tests

# Software best practices followed in this MR:
* [x] Reducing size of functions
* [x] Clear code using comments, docstrings, and typehinting
* [x] Small, frequent merges
* [x] Input verification

# Review steps:
* [ ] Reviewer has checked code functionality.
* [ ] Reviewer has checked code is tidy, follows best practises, and is well commented.

# Caveats
None

# Release notes
## General release notes
None.

## Technical release notes
Move pixel transformation methods to their own module.
