### PR TITLE
Alex/develop/recolour greyscale

### DIFF
--- a/rubiks/__init__.py
+++ b/rubiks/__init__.py
@@ -3,5 +3,5 @@ from .constants import *
 from .methods import *
 from .colour_class import Colour
 from .palette_class import Palette, PaletteWeights
-from .pixel_transformations import recolour_closest_weighted
-from .transformations import Transformation, NoneTransformation, RecolourClosest
+from .pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
+from .transformations import Transformation, NoneTransformation, RecolourClosest, RecolourClosestGreyscale

--- a/rubiks/colour_class.py
+++ b/rubiks/colour_class.py
@@ -3,8 +3,8 @@ Colour class for rubiks images.
 """
 
 from __future__ import annotations
-from .lib import is_permutation, check_type
 from typing import Any, Iterable
+from .lib import is_permutation, check_type
 
 # Some defaults for Colour:
 DEFAULT_COLOUR_ITERABLE = [0, 0, 0]
@@ -40,6 +40,7 @@ class Colour(list):
         self._values = None
         self._format = None
         self._channel_dict = None
+        self._greyscale = None
         self.__update(channel_format)
 
     @property
@@ -63,6 +64,13 @@ class Colour(list):
         """
         return self._channel_dict
 
+    @property
+    def greyscale(self) -> int:
+        """
+        The greyscale value of the colour.
+        """
+        return self._greyscale
+
     def __update(self, channel_format: list[str] | None = None) -> None:
         """
         Update various attributes.
@@ -78,6 +86,9 @@ class Colour(list):
             self._format = channel_format
         # Combined as a dictionary:
         self._channel_dict = {channel: value for channel, value in zip(self._format, self._values)}
+        # Calculate greyscale value:
+        b, g, r = self.channel_value("b"), self.channel_value("g"), self.channel_value("r")
+        self._greyscale = round(0.3 * r + 0.59 * g + 0.11 * b)
 
     def __setitem__(self, index: int, value: Any) -> None:
         """

--- a/rubiks/colour_class.py
+++ b/rubiks/colour_class.py
@@ -3,8 +3,9 @@ Colour class for rubiks images.
 """
 
 from __future__ import annotations
+import numpy as np
 from typing import Any, Iterable
-from .lib import is_permutation, check_type
+from .lib import is_permutation, check_type, pixel_to_greyscale
 
 # Some defaults for Colour:
 DEFAULT_COLOUR_ITERABLE = [0, 0, 0]
@@ -87,8 +88,8 @@ class Colour(list):
         # Combined as a dictionary:
         self._channel_dict = {channel: value for channel, value in zip(self._format, self._values)}
         # Calculate greyscale value:
-        b, g, r = self.channel_value("b"), self.channel_value("g"), self.channel_value("r")
-        self._greyscale = round(0.3 * r + 0.59 * g + 0.11 * b)
+        bgr = np.array([self.channel_value("b"), self.channel_value("g"), self.channel_value("r")])
+        self._greyscale = pixel_to_greyscale(bgr)
 
     def __setitem__(self, index: int, value: Any) -> None:
         """

--- a/rubiks/lib.py
+++ b/rubiks/lib.py
@@ -2,6 +2,7 @@
 Random useful internal functions.
 """
 
+import numpy as np
 from typing import Any, Iterable
 
 
@@ -36,3 +37,15 @@ def check_type(object: object, types: type | Iterable[type], name: str | None = 
         if name is None:
             name = "<this object>"
         raise TypeError(f"{type(object)} is an invalid type for {name} ({object}). Must be from {types}.")
+
+
+def pixel_to_greyscale(pixel: np.ndarray) -> int:
+    """
+    Convert a pixel with BGR colour channel format to an integer greyscale value.
+
+    :param pixel: a 1x3 np.array with integer colour channel values with BGR format.
+
+    :return: the greyscale value of the pixel
+    """
+
+    return round(pixel.dot([0.11, 0.59, 0.3]))

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -45,7 +45,8 @@ def recolour_closest_weighted_greyscale(
     greyscale values.
 
     :param pixel: a pixel.
-    :param palette: a palette of colours from which the final image will be constructed.
+    :param palette: a palette of colours from which the final image will be constructed. All colours must have the
+    same channel format as a cv2.Mat.
     :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
     influence each colour has.
 

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -56,7 +56,7 @@ def recolour_closest_weighted_greyscale(
     # Measure the Euclidean distance to the greyscale value of each colour in the palette:
     pixel_greyscale = pixel_to_greyscale(pixel)
     distances = {
-        colour_name: np.linalg.norm(pixel_greyscale - colour.greyscale) / palette_weights[colour_name]
+        colour_name: abs(pixel_greyscale - colour.greyscale) / palette_weights[colour_name]
         for colour_name, colour in palette.colour_dict.items()
     }
 

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -3,6 +3,7 @@ Rubiks pixel transformations.
 """
 
 import numpy as np
+from .lib import pixel_to_greyscale
 from .palette_class import Palette, PaletteWeights
 
 
@@ -53,7 +54,7 @@ def recolour_closest_weighted_greyscale(
     :return: the transformed pixel.
     """
     # Measure the Euclidean distance to the greyscale value of each colour in the palette:
-    pixel_greyscale = np.array([0.11, 0.59, 0.3]).dot(pixel)
+    pixel_greyscale = pixel_to_greyscale(pixel)
     distances = {
         colour_name: np.linalg.norm(pixel_greyscale - colour.greyscale) / palette_weights[colour_name]
         for colour_name, colour in palette.colour_dict.items()

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -35,3 +35,37 @@ def recolour_closest_weighted(pixel: np.ndarray, palette: Palette, palette_weigh
     closest_colour = np.random.choice(colours_with_smallest_distance)
 
     return np.array(palette[closest_colour])
+
+
+def recolour_closest_weighted_greyscale(
+    pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights
+) -> np.ndarray:
+    """
+    Change the colour of the pixel to the one from the palette which is geometrically closest when comparing their
+    greyscale values.
+
+    :param pixel: a pixel.
+    :param palette: a palette of colours from which the final image will be constructed.
+    :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
+    influence each colour has.
+
+    :return: the transformed pixel.
+    """
+    # Measure the Euclidean distance to the greyscale value of each colour in the palette:
+    pixel_greyscale = np.array([0.11, 0.59, 0.3]) * pixel
+    distances = {
+        colour_name: np.linalg.norm(pixel_greyscale - colour.greyscale) / palette_weights[colour_name]
+        for colour_name, colour in palette.colour_dict.items()
+    }
+
+    # Find the minimum distance:
+    smallest_distance = min(distances.values())
+    # Create a list of all the colour names with this distance:
+    colours_with_smallest_distance = [
+        colour_name for colour_name, distance in distances.items() if distance == smallest_distance
+    ]
+
+    # Choose one of these colours randomly:
+    closest_colour = np.random.choice(colours_with_smallest_distance)
+
+    return np.array(palette[closest_colour])

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -53,7 +53,7 @@ def recolour_closest_weighted_greyscale(
     :return: the transformed pixel.
     """
     # Measure the Euclidean distance to the greyscale value of each colour in the palette:
-    pixel_greyscale = np.array([0.11, 0.59, 0.3]) * pixel
+    pixel_greyscale = np.array([0.11, 0.59, 0.3]).dot(pixel)
     distances = {
         colour_name: np.linalg.norm(pixel_greyscale - colour.greyscale) / palette_weights[colour_name]
         for colour_name, colour in palette.colour_dict.items()

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -120,8 +120,8 @@ class RecolourClosest(Transformation):
 
         return recolour_closest_weighted(pixel, palette, palette_weights)
 
-    @staticmethod
-    def _validate_palette(palette: Palette) -> Palette:
+    @classmethod
+    def _validate_palette(cls, palette: Palette) -> Palette:
         """
         Do input validation for the palette.
 
@@ -134,8 +134,8 @@ class RecolourClosest(Transformation):
 
         return palette
 
-    @staticmethod
-    def _validate_weights(palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
+    @classmethod
+    def _validate_weights(cls, palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
         """
         Do input validation for the palette weights.
 
@@ -154,33 +154,10 @@ class RecolourClosest(Transformation):
         return palette_weights
 
 
-class RecolourClosestGreyscale(Transformation):
+class RecolourClosestGreyscale(RecolourClosest):
     """
     Recolour each pixel to the colour in the palette that is closest geometrically when converted to greyscale.
     """
-
-    @classmethod
-    def transform_image(
-        cls,
-        image: cv2.Mat,
-        palette: Palette,
-        palette_weights: PaletteWeights | None = None,
-    ) -> cv2.Mat:
-        """
-        Recolour each pixel of an image by chosing the colour in the palette which is geometrically closest when
-        converted to greyscale.
-
-        :param image: an image in the form of a cv2.Mat.
-        :param palette: a palette of colours from which the final image will be constructed.
-        :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
-        influence each colour has. Defaults to all colours having equal weights.
-
-        :return: an image (cv2.Mat) made up of the colours in the given palette.
-        """
-        # Input verification for the weights (if None, creates equal weight for each colour):
-        palette_weights = cls._validate_weights(palette, palette_weights)
-
-        return super()._apply_to_all_pixels(image, palette, palette_weights)
 
     @classmethod
     def _transform_pixel(cls, pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
@@ -198,22 +175,3 @@ class RecolourClosestGreyscale(Transformation):
         """
 
         return recolour_closest_weighted_greyscale(pixel, palette, palette_weights)
-
-    @staticmethod
-    def _validate_weights(palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
-        """
-        Do input validation for the palette weights.
-
-        :param palette: a Palette of Colours.
-        :param pallete_weights: a PaletteWeights instance.
-
-        :return: palette_weights
-        """
-        # If we haven't been given any weights, assign each colour a weight of 1:
-        if palette_weights is None:
-            palette_weights = PaletteWeights({colour_name: 1 for colour_name in palette.names})
-
-        # Check that the palette weights and palette share the same colours:
-        palette_weights.validate_against_palette(palette)
-
-        return palette_weights

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -7,7 +7,7 @@ import numpy as np
 import cv2
 from .palette_class import Palette, PaletteWeights
 from .constants import CV2_CHANNEL_FORMAT
-from .pixel_transformations import recolour_closest_weighted
+from .pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
 
 
 class Transformation(ABC):
@@ -133,6 +133,71 @@ class RecolourClosest(Transformation):
         palette.reformat(CV2_CHANNEL_FORMAT)
 
         return palette
+
+    @staticmethod
+    def _validate_weights(palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
+        """
+        Do input validation for the palette weights.
+
+        :param palette: a Palette of Colours.
+        :param pallete_weights: a PaletteWeights instance.
+
+        :return: palette_weights
+        """
+        # If we haven't been given any weights, assign each colour a weight of 1:
+        if palette_weights is None:
+            palette_weights = PaletteWeights({colour_name: 1 for colour_name in palette.names})
+
+        # Check that the palette weights and palette share the same colours:
+        palette_weights.validate_against_palette(palette)
+
+        return palette_weights
+
+
+class RecolourClosestGreyscale(Transformation):
+    """
+    Recolour each pixel to the colour in the palette that is closest geometrically when converted to greyscale.
+    """
+
+    @classmethod
+    def transform_image(
+        cls,
+        image: cv2.Mat,
+        palette: Palette,
+        palette_weights: PaletteWeights | None = None,
+    ) -> cv2.Mat:
+        """
+        Recolour each pixel of an image by chosing the colour in the palette which is geometrically closest when
+        converted to greyscale.
+
+        :param image: an image in the form of a cv2.Mat.
+        :param palette: a palette of colours from which the final image will be constructed.
+        :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
+        influence each colour has. Defaults to all colours having equal weights.
+
+        :return: an image (cv2.Mat) made up of the colours in the given palette.
+        """
+        # Input verification for the weights (if None, creates equal weight for each colour):
+        palette_weights = cls._validate_weights(palette, palette_weights)
+
+        return super()._apply_to_all_pixels(image, palette, palette_weights)
+
+    @classmethod
+    def _transform_pixel(cls, pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
+        """
+        Change the colour of the pixel to the one from the palette which is geometrically closest when converted to
+        greyscale.
+
+        :param pixel: a pixel.
+        :param palette: a palette of colours from which the final image will be constructed. All colours must have the
+        same channel format as a cv2.Mat.
+        :param palette_weights: a map from colour names to "weights", which will determine how big of a sphere of
+        influence each colour has.
+
+        :return: the transformed pixel.
+        """
+
+        return recolour_closest_weighted_greyscale(pixel, palette, palette_weights)
 
     @staticmethod
     def _validate_weights(palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -120,8 +120,8 @@ class RecolourClosest(Transformation):
 
         return recolour_closest_weighted(pixel, palette, palette_weights)
 
-    @classmethod
-    def _validate_palette(cls, palette: Palette) -> Palette:
+    @staticmethod
+    def _validate_palette(palette: Palette) -> Palette:
         """
         Do input validation for the palette.
 
@@ -134,8 +134,8 @@ class RecolourClosest(Transformation):
 
         return palette
 
-    @classmethod
-    def _validate_weights(cls, palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
+    @staticmethod
+    def _validate_weights(palette: Palette, palette_weights: PaletteWeights | None) -> PaletteWeights:
         """
         Do input validation for the palette weights.
 

--- a/test/test_pixel_tranformations.py
+++ b/test/test_pixel_tranformations.py
@@ -2,6 +2,7 @@ import numpy as np
 import unittest
 
 from rubiks.constants import RUBIKS_PALETTE
+from rubiks.palette_class import PaletteWeights
 from rubiks.pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
 
 
@@ -14,7 +15,7 @@ class RecolourClosestWeightedTest(unittest.TestCase):
 
         self.pixel = np.array([200, 200, 200], dtype=np.uint8)
         self.palette = RUBIKS_PALETTE
-        self.weights = {colour_name: 1 for colour_name in self.palette.names}
+        self.weights = PaletteWeights({colour_name: 1 for colour_name in self.palette.names})
 
     def test_regular(self) -> None:
         """
@@ -32,14 +33,14 @@ class RecolourClosestWeightedGreyscaleTest(unittest.TestCase):
 
     def setUp(self) -> None:
 
-        self.pixel = np.array([200, 200, 200], dtype=np.uint8)
+        self.pixel = np.array([20, 200, 200], dtype=np.uint8)
         self.palette = RUBIKS_PALETTE
-        self.weights = {colour_name: 1 for colour_name in self.palette.names}
+        self.weights = PaletteWeights({colour_name: 1 for colour_name in self.palette.names})
 
     def test_regular(self) -> None:
         """
         Test that recolouring a pixel returns the expected colour.
         """
         np.testing.assert_array_equal(
-            recolour_closest_weighted_greyscale(self.pixel, self.palette, self.weights), np.array([52, 18, 183])
+            recolour_closest_weighted_greyscale(self.pixel, self.palette, self.weights), np.array([0, 213, 255])
         )

--- a/test/test_pixel_tranformations.py
+++ b/test/test_pixel_tranformations.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from rubiks.constants import RUBIKS_PALETTE
-from rubiks.pixel_transformations import recolour_closest_weighted
+from rubiks.pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
 
 
 class RecolourClosestWeightedTest(unittest.TestCase):
@@ -22,4 +22,24 @@ class RecolourClosestWeightedTest(unittest.TestCase):
         """
         np.testing.assert_array_equal(
             recolour_closest_weighted(self.pixel, self.palette, self.weights), np.array([255, 255, 255])
+        )
+
+
+class RecolourClosestWeightedGreyscaleTest(unittest.TestCase):
+    """
+    Test the recolour_closest_weighted_greyscale function.
+    """
+
+    def setUp(self) -> None:
+
+        self.pixel = np.array([200, 200, 200], dtype=np.uint8)
+        self.palette = RUBIKS_PALETTE
+        self.weights = {colour_name: 1 for colour_name in self.palette.names}
+
+    def test_regular(self) -> None:
+        """
+        Test that recolouring a pixel returns the expected colour.
+        """
+        np.testing.assert_array_equal(
+            recolour_closest_weighted_greyscale(self.pixel, self.palette, self.weights), np.array([52, 18, 183])
         )

--- a/test/test_transformations.py
+++ b/test/test_transformations.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from rubiks.palette_class import Palette, PaletteWeights
-from rubiks.transformations import Transformation, NoneTransformation, RecolourClosest
+from rubiks.transformations import Transformation, NoneTransformation, RecolourClosest, RecolourClosestGreyscale
 
 
 class TransformationTest(unittest.TestCase):
@@ -140,3 +140,78 @@ class RecolourClosestTest(unittest.TestCase):
         invalid_weights = PaletteWeights({"white": 1, "black": 2, "extra": 3})
         with self.assertRaises(ValueError):
             RecolourClosest.transform_image(self.image, self.palette, palette_weights=invalid_weights)
+
+
+class RecolourClosestGreyscaleTest(unittest.TestCase):
+    """
+    Test the RecolourClosestGreyscale class.
+    """
+
+    def setUp(self) -> None:
+
+        self.image = np.array(
+            [
+                [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                [[3, 3, 3], [4, 4, 4], [5, 5, 5]],
+                [[6, 6, 6], [7, 7, 7], [8, 8, 8]],
+            ],
+            dtype=np.uint8,
+        )
+        self.palette = Palette()
+
+    def test_regular_weights(self) -> None:
+        """
+        Test that applying the RecolourClosestGreyscale transformation on an image returns the correct result when using
+        palette weights.
+        """
+        weights = PaletteWeights({"white": 250, "black": 1})
+        equivalent_image = np.array(
+            [
+                [[0, 0, 0], [0, 0, 0], [255, 255, 255]],
+                [[255, 255, 255], [255, 255, 255], [255, 255, 255]],
+                [[255, 255, 255], [255, 255, 255], [255, 255, 255]],
+            ],
+            dtype=np.uint8,
+        )
+        np.testing.assert_array_equal(
+            RecolourClosestGreyscale.transform_image(self.image, Palette(), palette_weights=weights), equivalent_image
+        )
+
+    def test_regular_no_weights(self) -> None:
+        """
+        Test that applying the RecolourClosestGreyscale transformation on an image returns the correct result when not
+        using palette weights.
+        """
+        image = np.array(
+            [
+                [[1, 1, 1], [2, 2, 2], [155, 155, 155]],
+                [[155, 155, 155], [255, 255, 255], [255, 255, 255]],
+                [[255, 255, 255], [255, 255, 255], [55, 55, 55]],
+            ],
+            dtype=np.uint8,
+        )
+        equivalent_image = np.array(
+            [
+                [[0, 0, 0], [0, 0, 0], [255, 255, 255]],
+                [[255, 255, 255], [255, 255, 255], [255, 255, 255]],
+                [[255, 255, 255], [255, 255, 255], [0, 0, 0]],
+            ],
+            dtype=np.uint8,
+        )
+        np.testing.assert_array_equal(RecolourClosestGreyscale.transform_image(image, Palette()), equivalent_image)
+
+    def test_missing_weights(self) -> None:
+        """
+        Test that supplying PaletteWeights with one of the colours missing raises a ValueError.
+        """
+        invalid_weights = PaletteWeights({"white": 1})
+        with self.assertRaises(ValueError):
+            RecolourClosestGreyscale.transform_image(self.image, self.palette, palette_weights=invalid_weights)
+
+    def test_extra_weights(self) -> None:
+        """
+        Test that supplying PaletteWeights with one of the colours missing raises a ValueError.
+        """
+        invalid_weights = PaletteWeights({"white": 1, "black": 2, "extra": 3})
+        with self.assertRaises(ValueError):
+            RecolourClosestGreyscale.transform_image(self.image, self.palette, palette_weights=invalid_weights)


### PR DESCRIPTION
Closes #5 

Add a transformation, `RecolourClosestGreyscale`,  which recolours to the colour in the palette with the most similar greyscale value.

# Description
An image transformation is added, which recolours each pixel to the colour from the palette which is most similar when comparing greyscale values.

# Tests
* [x] CI pipeline passes
* [x] Transformation works for image in unit test

## Evidence
~~Add evidence of the above tests having been completed here, via screenshots, links, or text.~~

# Documentation
* [ ] ~~Documentation updated (where relevant - please provide a link!)~~

# Test coverage
* [x] New code covered by unit tests

# Software best practices followed in this MR:
* [x] Reducing size of functions
* [x] Clear code using comments, docstrings, and typehinting
* [x] Small, frequent merges
* [x] Input verification

# Review steps:
* [ ] Reviewer has checked code functionality.
* [ ] Reviewer has checked code is tidy, follows best practises, and is well commented.

# Caveats
- This new transformation currently inherits from `RecolourClosest` so that it inherits the input verification methods, but those should probably be in a separate parent class for both of these transformations. #18 

# Release notes
## General release notes
Add a transformation, `RecolourClosestGreyscale`,  which recolours to the colour in the palette with the most similar greyscale value.

## Technical release notes
- A new subclass of `Transformation`, `RecolouClosestGreyscale`, is added
- `Colour` now has a `.greyscale` property, which returns the integer greyscale value from 0-255 of the colour
- A new method is added to `lib` - `pixel_to_greyscale`, which converts a cv2 pixel to its greyscale value
