### PR TITLE
Fix reversed width/height when estimating dimensions

### DIFF
--- a/create_image.py
+++ b/create_image.py
@@ -15,7 +15,7 @@ cv2.waitKey(0)
 # # Estimate the best dimensions for the final image:
 # (new_height, new_width) = rubiks.rubiks_dimension_estimator(regular_image, n_cubes, reporting=True)
 n_cubes = 400
-new_height, new_width = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
+new_width, new_height = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
 print((new_height, new_width))
 
 # # Resize the image:

--- a/create_image.py
+++ b/create_image.py
@@ -15,7 +15,7 @@ cv2.waitKey(0)
 # # Estimate the best dimensions for the final image:
 # (new_height, new_width) = rubiks.rubiks_dimension_estimator(regular_image, n_cubes, reporting=True)
 n_cubes = 400
-new_width, new_height = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
+new_height, new_width = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
 print((new_height, new_width))
 
 # # Resize the image:

--- a/create_image.py
+++ b/create_image.py
@@ -15,8 +15,8 @@ cv2.waitKey(0)
 # # Estimate the best dimensions for the final image:
 # (new_height, new_width) = rubiks.rubiks_dimension_estimator(regular_image, n_cubes, reporting=True)
 n_cubes = 400
-new_height, new_width = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
-print((new_height, new_width))
+new_width, new_height = rubiks.rubiks_dimension_estimator(n_cubes, image=regular_image)
+print((new_width, new_height))
 
 # # Resize the image:
 # resized_regular_image = rubiks.resize_image(regular_image, new_height=new_height, new_width=new_width)

--- a/rubiks/methods.py
+++ b/rubiks/methods.py
@@ -23,7 +23,7 @@ def rubiks_dimension_estimator(
     :param height: the height of the input image in pixels.
     :param image: a cv2.Mat.
 
-    :return: output_dimensions the dimensions of the resulting rubiks image (in rubiks tiles).
+    :return: the dimensions of the resulting rubiks image (in rubiks tiles) in the format (width, height).
     """
     # Verify inputs:
     # Check that we either have both width and height and NOT image, or have image and NEITHER of width and height:


### PR DESCRIPTION
Closes #22

# Description
create_image.py was estimating the dimensions of the file reversed.

# Tests
* [x] CI pipeline passes

## Evidence
Add evidence of the above tests having been completed here, via screenshots, links, or text.

<details> <summary> Before </summary>

![image](https://github.com/anakinlong/rubiks/assets/29843733/3a70102b-c63a-4d9b-9601-d70ecd0b842d)

</details>

<details> <summary> After</summary>

![image](https://github.com/anakinlong/rubiks/assets/29843733/e5e41519-e682-41ca-bdf2-d424fb8740b8)

</details>

# Documentation
* [x] Documentation updated (where relevant - please provide a link!)

# Software best practices followed in this MR:
* [x] Small, frequent merges
* [x] Input verification

# Review steps:
* [x] Reviewer has checked code functionality.
* [ ] Reviewer has checked code is tidy, follows best practises, and is well commented.


