### PR TITLE
Add pixel class

### DIFF
--- a/rubiks/__init__.py
+++ b/rubiks/__init__.py
@@ -3,5 +3,6 @@ from .constants import *
 from .methods import *
 from .colour_class import Colour
 from .palette_class import Palette, PaletteWeights
+from .pixel_class import Pixel
 from .pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
 from .transformations import Transformation, NoneTransformation, RecolourClosest, RecolourClosestGreyscale

--- a/rubiks/pixel_class.py
+++ b/rubiks/pixel_class.py
@@ -2,10 +2,10 @@
 Colour class for rubiks images.
 """
 
-from __future__ import annotations
 import numpy as np
 from typing import Any, Iterable
-from .lib import check_type
+
+from numpy._typing import NDArray
 
 
 class Pixel(np.ndarray):
@@ -13,68 +13,46 @@ class Pixel(np.ndarray):
     A pixel :^). This is basically a numpy.ndarray with a few extra features.
     """
 
-    def __init__(self, iterable: Iterable[int], coordinates: tuple[int | None] = (None, None)) -> None:
+    def __new__(cls, array: np.ndarray[int], coordinates: tuple[int | None] = (None, None)) -> None:
         """
         A pixel :^). This is basically a numpy.ndarray with a few extra features.
 
         :param iterable: an iterable with length three containing positive integer elements.
         :param coordinates: an iterable with length three containing positive integer elements.
         """
+        # np.ndarrays are weird to subclass. See https://numpy.org/doc/stable/user/basics.subclassing.html
         # Input validation:
-        Pixel.__validate_iterable(iterable)
+        Pixel.__validate_array(array)
 
-        # Do regular ndarray stuff:
-        super().__init__(iterable)
+        # Create an ndarray:
+        obj = np.asarray(array).view(cls)
 
         # Store the coordinates:
-        self._x, self._y = coordinates
+        obj.x, obj.y = coordinates
 
-    @property
-    def x(self) -> int:
-        """
-        The 0-indexed x coordinate of the pixel in its image.
-        """
-        return self._x
+        return obj
 
-    @property
-    def y(self) -> int:
+    def __array_finalize__(self, obj: np.ndarray[int]) -> None:
         """
-        The 0-indexed y coordinate of the pixel in its image.
+        Set the public attributes of the new ndarray.
         """
-        return self._y
-
-    def __setitem__(self, index: int, value: Any) -> None:
-        """
-        Set self[index] to value.
-
-        :param index: the index.
-        :param value: the value.
-
-        :return: None
-        """
-        # Do the regular ndarray __setitem__:
-        super().__setitem__(index, value)
-
-        # Check this is still a valid pixel:
-        Pixel.__validate_iterable(self)
+        self.x = getattr(obj, "x", None)
+        self.y = getattr(obj, "y", None)
 
     @staticmethod
-    def __validate_iterable(iterable: Iterable[int]) -> None:
+    def __validate_array(array: np.ndarray[int]) -> None:
         """
-        Check the given iterable is acceptable.
+        Check the given array is acceptable.
 
-        :param iterable: an iterable (supposedly).
+        :param array: an array (supposedly).
 
         :return: None
         """
         # Check the type is correct:
         try:
-            iter(iterable)
+            iter(array)
         except TypeError:
             raise
         # Check the length is correct:
-        if len(iterable) != 3:
-            raise ValueError(f"Iterable must have exactly 3 elements. Found {len(iterable)}.\n{iterable}")
-        # Check the types of the elements are correct:
-        for element in iterable:
-            check_type(element, int, "an element of the pixel iterable")
+        if len(array) != 3:
+            raise ValueError(f"Array must have exactly 3 elements. Found {len(array)}.\n{array}")

--- a/rubiks/pixel_class.py
+++ b/rubiks/pixel_class.py
@@ -1,0 +1,80 @@
+"""
+Colour class for rubiks images.
+"""
+
+from __future__ import annotations
+import numpy as np
+from typing import Any, Iterable
+from .lib import check_type
+
+
+class Pixel(np.ndarray):
+    """
+    A pixel :^). This is basically a numpy.ndarray with a few extra features.
+    """
+
+    def __init__(self, iterable: Iterable[int], coordinates: tuple[int | None] = (None, None)) -> None:
+        """
+        A pixel :^). This is basically a numpy.ndarray with a few extra features.
+
+        :param iterable: an iterable with length three containing positive integer elements.
+        :param coordinates: an iterable with length three containing positive integer elements.
+        """
+        # Input validation:
+        Pixel.__validate_iterable(iterable)
+
+        # Do regular ndarray stuff:
+        super().__init__(iterable)
+
+        # Store the coordinates:
+        self._x, self._y = coordinates
+
+    @property
+    def x(self) -> int:
+        """
+        The 0-indexed x coordinate of the pixel in its image.
+        """
+        return self._x
+
+    @property
+    def y(self) -> int:
+        """
+        The 0-indexed y coordinate of the pixel in its image.
+        """
+        return self._y
+
+    def __setitem__(self, index: int, value: Any) -> None:
+        """
+        Set self[index] to value.
+
+        :param index: the index.
+        :param value: the value.
+
+        :return: None
+        """
+        # Do the regular ndarray __setitem__:
+        super().__setitem__(index, value)
+
+        # Check this is still a valid pixel:
+        Pixel.__validate_iterable(self)
+
+    @staticmethod
+    def __validate_iterable(iterable: Iterable[int]) -> None:
+        """
+        Check the given iterable is acceptable.
+
+        :param iterable: an iterable (supposedly).
+
+        :return: None
+        """
+        # Check the type is correct:
+        try:
+            iter(iterable)
+        except TypeError:
+            raise
+        # Check the length is correct:
+        if len(iterable) != 3:
+            raise ValueError(f"Iterable must have exactly 3 elements. Found {len(iterable)}.\n{iterable}")
+        # Check the types of the elements are correct:
+        for element in iterable:
+            check_type(element, int, "an element of the pixel iterable")

--- a/rubiks/pixel_class.py
+++ b/rubiks/pixel_class.py
@@ -17,7 +17,7 @@ class Pixel(np.ndarray):
         """
         A pixel :^). This is basically a numpy.ndarray with a few extra features.
 
-        :param iterable: an iterable with length three containing positive integer elements.
+        :param array: an iterable with length three containing positive integer elements.
         :param coordinates: an iterable with length three containing positive integer elements.
         """
         # np.ndarrays are weird to subclass. See https://numpy.org/doc/stable/user/basics.subclassing.html

--- a/rubiks/pixel_class.py
+++ b/rubiks/pixel_class.py
@@ -1,5 +1,5 @@
 """
-Colour class for rubiks images.
+Pixel class for rubiks images.
 """
 
 import numpy as np

--- a/rubiks/pixel_transformations.py
+++ b/rubiks/pixel_transformations.py
@@ -5,9 +5,10 @@ Rubiks pixel transformations.
 import numpy as np
 from .lib import pixel_to_greyscale
 from .palette_class import Palette, PaletteWeights
+from .pixel_class import Pixel
 
 
-def recolour_closest_weighted(pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
+def recolour_closest_weighted(pixel: Pixel, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
     """
     Change the colour of the pixel to the one from the palette which is geometrically closest.
 
@@ -38,9 +39,7 @@ def recolour_closest_weighted(pixel: np.ndarray, palette: Palette, palette_weigh
     return np.array(palette[closest_colour])
 
 
-def recolour_closest_weighted_greyscale(
-    pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights
-) -> np.ndarray:
+def recolour_closest_weighted_greyscale(pixel: Pixel, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
     """
     Change the colour of the pixel to the one from the palette which is geometrically closest when comparing their
     greyscale values.

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -29,7 +29,7 @@ class Transformation(ABC):
 
     @classmethod
     @abstractmethod
-    def _transform_pixel(cls, pixel: np.ndarray, *args, **kwargs) -> np.ndarray:
+    def _transform_pixel(cls, pixel: Pixel, *args, **kwargs) -> np.ndarray:
         """
         Main transform method for a pixel. Must be implemented by child classes.
 
@@ -71,7 +71,7 @@ class NoneTransformation(Transformation):
     """
 
     @classmethod
-    def _transform_pixel(cls, pixel: np.ndarray, *args, **kwargs) -> np.ndarray:
+    def _transform_pixel(cls, pixel: Pixel, *args, **kwargs) -> np.ndarray:
 
         return pixel
 
@@ -145,7 +145,7 @@ class RecolourClosest(TransformationFromPalette):
     """
 
     @classmethod
-    def _transform_pixel(cls, pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
+    def _transform_pixel(cls, pixel: Pixel, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
         """
         Change the colour of the pixel to the one from the palette which is geometrically closest.
 
@@ -167,7 +167,7 @@ class RecolourClosestGreyscale(TransformationFromPalette):
     """
 
     @classmethod
-    def _transform_pixel(cls, pixel: np.ndarray, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
+    def _transform_pixel(cls, pixel: Pixel, palette: Palette, palette_weights: PaletteWeights) -> np.ndarray:
         """
         Change the colour of the pixel to the one from the palette which is geometrically closest when converted to
         greyscale.

--- a/rubiks/transformations.py
+++ b/rubiks/transformations.py
@@ -7,6 +7,7 @@ import numpy as np
 import cv2
 from .palette_class import Palette, PaletteWeights
 from .constants import CV2_CHANNEL_FORMAT
+from .pixel_class import Pixel
 from .pixel_transformations import recolour_closest_weighted, recolour_closest_weighted_greyscale
 
 
@@ -57,7 +58,7 @@ class Transformation(ABC):
         for x in range(width):
             for y in range(height):
                 # Find the current pixel:
-                original_pixel = image[y, x]
+                original_pixel = Pixel(image[y, x])
                 # Transform it:
                 transformed_image[y, x] = cls._transform_pixel(original_pixel, *args, **kwargs)
 

--- a/test/test_pixel.py
+++ b/test/test_pixel.py
@@ -1,0 +1,40 @@
+import numpy as np
+import unittest
+
+from rubiks.pixel_class import Pixel
+
+
+class PixelTest(unittest.TestCase):
+    """
+    Test some use cases for the Pixel class.
+    """
+
+    def setUp(self) -> None:
+
+        self.pixel = Pixel([1, 2, 3], coordinates=(0, 127))
+
+    def test_x(self) -> None:
+        """
+        Test that the values property returns the expected result.
+        """
+        self.assertEqual(self.pixel.x, 0)
+
+    def test_y(self) -> None:
+        """
+        Test that the values property returns the expected result.
+        """
+        self.assertEqual(self.pixel.y, 127)
+
+    def test_array_type(self) -> None:
+        """
+        Test that supplying something other than an array or iterable raises an error when creating a Pixel.
+        """
+        with self.assertRaises(TypeError):
+            Pixel(None)
+
+    def test_array_element_type(self) -> None:
+        """
+        Test that supplying an array with a length not equal to 3 raises an error when creating a Pixel.
+        """
+        with self.assertRaises(ValueError):
+            Pixel(np.asarray([1, 2, 3, 4]))


### PR DESCRIPTION

Closes #26 

Add a pixel class.

# Description
Add a pixel class, so that we can pass more information to pixel transformations about the original pixel in the image, e.g. the coordinates.

# Tests
* [x] CI pipeline passes

## Evidence

# Documentation
* [ ] ~~Documentation updated (where relevant - please provide a link!)~~

# Test coverage
* [x] New code covered by unit tests

# Software best practices followed in this MR:
* [x] Reducing size of functions
* [x] Clear code using comments, docstrings, and typehinting
* [x] Small, frequent merges
* [x] Input verification

# Review steps:
* [ ] Reviewer has checked code functionality.
* [ ] Reviewer has checked code is tidy, follows best practises, and is well commented.

# Caveats

# Release notes
## General release notes
None

## Technical release notes
Add a pixel class. Each pixel in a transformation is now passed to the corresponding pixel transformation as a Pixel instance.
